### PR TITLE
WIP: add flow annotations

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = {
+  webpack: {
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: "babel-loader"
+        }
+      ]
+    }
+  }
+};

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,34 @@
+{
+  "env": {
+    "development": {
+      "sourceMaps": "inline",
+      "comments": false,
+      "presets": [
+        [
+          "env",
+          {
+            "targets": {
+              "node": "current"
+            }
+          }
+        ],
+        "flow-node"
+      ]
+    },
+    "umd": {
+      "comments": false,
+      "presets": [
+        [
+          "env",
+          {
+            "modules": false,
+            "targets": {
+              "browsers": "last 2 versions"
+            }
+          }
+        ],
+        "flow-node"
+      ]
+    }
+  }
+}

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,9 @@
+[ignore]
+.*/node_modules/documentation/*
+ 
+[libs]
+ 
+[include]
+ 
+[options]
+suppress_comment= \\(.\\|\n\\)*\\@FlowIgnore

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ yarn.lock
 package-lock.json
 
 dist
+lib
 docs

--- a/example.js
+++ b/example.js
@@ -1,3 +1,4 @@
+/* eslint-disable strict */ /* eslint-disable no-console */
 'use strict'
 
 const multibase = require('multibase')

--- a/flow-typed/npm/base-x_v3.0.4.js
+++ b/flow-typed/npm/base-x_v3.0.4.js
@@ -1,0 +1,16 @@
+// @flow
+// flow-typed signature: ca400f8732729fff6ccfd6b85d42d0bb
+// flow-typed version: 0.1.0/base-x_v3.0.4/flow_v0.69.0
+
+declare module 'base-x' {
+  declare type BaseEngine = {
+    encode: (buffer: string | Buffer) => string,
+    decode: (string: string) => number[]
+  }
+
+  declare type BaseImplementation = (ALPHABET: string) => BaseEngine;
+
+  declare var baseX: BaseImplementation;
+
+  declare export default baseX;
+}

--- a/package.json
+++ b/package.json
@@ -4,17 +4,22 @@
   "description": "JavaScript implementation of the multibase specification",
   "main": "src/index.js",
   "scripts": {
-    "lint": "aegir lint",
-    "test": "aegir test",
-    "test:node": "aegir test -t node",
-    "test:browser": "aegir test -t browser",
-    "build": "aegir build",
+    "lint": "aegir lint && npm run type-check",
+    "test": "npm run build:node && aegir test",
+    "test:node": "npm run build:node && aegir test --target node",
+    "test:browser": "npm run build && aegir test --target browser",
+    "type-check": "flow check",
+    "build": "npm run build:node && BABEL_ENV=umd aegir build",
     "docs": "aegir docs",
     "release": "aegir release --docs",
     "release-minor": "aegir release --type minor --docs",
     "release-major": "aegir release --type major --docs",
     "coverage": "aegir coverage",
-    "coverage-publish": "aegir coverage publish"
+    "coverage-publish": "aegir coverage publish",
+    "build:types": "flow-copy-source --verbose src lib",
+    "build:lib": "babel --out-dir lib src",
+    "build:node": "npm run build:types && npm run build:lib",
+    "start": "flow-copy-source --watch --verbose src lib & babel --watch --out-dir lib src"
   },
   "pre-commit": [
     "lint",
@@ -33,9 +38,15 @@
     "formats"
   ],
   "devDependencies": {
-    "aegir": "^12.3.0",
+    "aegir": "ipfs/aegir#flow",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.4",
+    "babel-preset-flow-node": "^2.0.1",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
+    "flow-bin": "^0.69.0",
+    "flow-copy-source": "^1.3.0",
     "pre-commit": "^1.2.2"
   },
   "dependencies": {

--- a/src/base.js
+++ b/src/base.js
@@ -1,26 +1,46 @@
-'use strict'
+// @flow
 
-class Base {
-  constructor (name, code, implementation, alphabet) {
+export interface BaseEngine {
+  encode(input: string | Buffer): string;
+  decode(input: string): Buffer;
+}
+
+export type BaseImplementation = (alphabet: string) => BaseEngine
+
+export class Base {
+  name: string
+  code: string
+  implementation: BaseImplementation
+  alphabet: string
+  engine: BaseEngine | void;
+
+  constructor (
+    name: string,
+    code: string,
+    implementation: '' | BaseImplementation,
+    alphabet: string
+  ) {
     this.name = name
     this.code = code
     this.alphabet = alphabet
+    // TODO: There are 3 possible solutions to resolve the error this causes:
+    // 1. Throw in here if there is no implementation
+    // 2. Throw when encode or decode are called without an engine present
+    // 3. Let encode or decode return undefined;
     if (implementation && alphabet) {
       this.engine = implementation(alphabet)
     }
   }
 
-  encode (stringOrBuffer) {
+  encode (stringOrBuffer: string | Buffer) {
     return this.engine.encode(stringOrBuffer)
   }
 
-  decode (stringOrBuffer) {
-    return this.engine.decode(stringOrBuffer)
+  decode (string: string) {
+    return this.engine.decode(string)
   }
 
-  isImplemented () {
-    return this.engine
+  isImplemented (): boolean {
+    return Boolean(this.engine)
   }
 }
-
-module.exports = Base

--- a/src/base16.js
+++ b/src/base16.js
@@ -1,6 +1,7 @@
-'use strict'
+// @flow
+import type { BaseEngine } from './base'
 
-module.exports = function base16 (alphabet) {
+export function base16 (alphabet: string): BaseEngine {
   return {
     encode (input) {
       if (typeof input === 'string') {

--- a/src/base32.js
+++ b/src/base32.js
@@ -1,5 +1,8 @@
-'use strict'
+// @flow
+import type { BaseEngine } from './base'
 
+// TODO: This returns an ArrayBuffer we probably have to convert it to a node
+// buffer. Or is this correct and should be casted?
 function decode (input, alphabet) {
   input = input.replace(new RegExp('=', 'g'), '')
   let length = input.length
@@ -59,7 +62,7 @@ function encode (buffer, alphabet) {
   return output
 }
 
-module.exports = function base32 (alphabet) {
+export function base32 (alphabet: string): BaseEngine {
   return {
     encode (input) {
       if (typeof input === 'string') {

--- a/src/base64.js
+++ b/src/base64.js
@@ -1,6 +1,7 @@
-'use strict'
+// @flow
+import type { BaseEngine } from './base'
 
-module.exports = function base64 (alphabet) {
+export function base64 (alphabet: string): BaseEngine {
   // The alphabet is only used to know:
   //   1. If padding is enabled (must contain '=')
   //   2. If the output must be url-safe (must contain '-' and '_')

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,13 +1,22 @@
-'use strict'
+// @flow
 
-const Base = require('./base.js')
-const baseX = require('base-x')
-const base16 = require('./base16')
-const base32 = require('./base32')
-const base64 = require('./base64')
+// TODO: These typings don't seem to get loaded
+import baseX from 'base-x'
+import { Base } from './base'
+import { base16 } from './base16'
+import { base32 } from './base32'
+import { base64 } from './base64'
+
+import type { BaseImplementation } from './base'
+
+// TODO: Should we change those to union types?
+type BaseName = string
+type BaseCode = string;
+type BaseAlphabet = string
+type BaseData = [BaseName, BaseCode, BaseImplementation | '', BaseAlphabet]
 
 // name, code, implementation, alphabet
-const constants = [
+const baseDataSet: BaseData[] = [
   ['base1', '1', '', '1'],
   ['base2', '0', baseX, '01'],
   ['base8', '7', baseX, '01234567'],
@@ -26,17 +35,17 @@ const constants = [
   ['base64urlpad', 'U', base64, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=']
 ]
 
-const names = constants.reduce((prev, tupple) => {
+const names: { [name: BaseName]: Base } = baseDataSet.reduce((prev, tupple) => {
   prev[tupple[0]] = new Base(tupple[0], tupple[1], tupple[2], tupple[3])
   return prev
 }, {})
 
-const codes = constants.reduce((prev, tupple) => {
+const codes: { [name: BaseCode]: Base } = baseDataSet.reduce((prev, tupple) => {
   prev[tupple[1]] = names[tupple[0]]
   return prev
 }, {})
 
-module.exports = {
+export const constants = {
   names: names,
   codes: codes
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,14 @@
+// @flow
+
 /**
  * Implementation of the [multibase](https://github.com/multiformats/multibase) specification.
  * @module Multibase
  */
-'use strict'
+import { constants } from './constants'
 
-const constants = require('./constants')
-
-exports = module.exports = multibase
-exports.encode = encode
-exports.decode = decode
-exports.isEncoded = isEncoded
+multibase.encode = encode
+multibase.decode = decode
+multibase.isEncoded = isEncoded
 
 const errNotSupported = new Error('Unsupported encoding')
 
@@ -21,7 +20,10 @@ const errNotSupported = new Error('Unsupported encoding')
  * @memberof Multibase
  * @returns {Buffer}
  */
-function multibase (nameOrCode, buf) {
+export default function multibase (
+  nameOrCode: string | number,
+  buf: Buffer
+): Buffer {
   if (!buf) {
     throw new Error('requires an encoded buffer')
   }
@@ -41,7 +43,7 @@ function multibase (nameOrCode, buf) {
  * @returns {Buffer}
  * @memberof Multibase
  */
-function encode (nameOrCode, buf) {
+function encode (nameOrCode: string | number, buf: Buffer): Buffer {
   const base = getBase(nameOrCode)
   const name = base.name
 
@@ -51,51 +53,35 @@ function encode (nameOrCode, buf) {
 /**
  *
  * Takes a buffer or string encoded with multibase header
- * decodes it and returns an object with the decoded buffer
- * and the encoded type { base: <name>, data: <buffer> }
- *
- * from @theobat : This is not what the multibase.spec.js test is waiting for,
- * hence the return decodeObject.data
+ * decodes it and returns the decoded buffer
  *
  * @param {Buffer|string} bufOrString
- * @returns {Object} result
- * @returns {string} result.base
- * @returns {Buffer} result.data
+ * @returns {Buffer}
  * @memberof Multibase
  *
  */
-function decode (bufOrString) {
-  if (Buffer.isBuffer(bufOrString)) {
-    bufOrString = bufOrString.toString()
-  }
+function decode (bufOrString: Buffer | string): Buffer {
+  bufOrString = bufOrString.toString()
 
   const code = bufOrString.substring(0, 1)
   bufOrString = bufOrString.substring(1, bufOrString.length)
 
-  if (typeof bufOrString === 'string') {
-    bufOrString = Buffer.from(bufOrString)
-  }
+  bufOrString = Buffer.from(bufOrString)
 
   const base = getBase(code)
 
-  const decodeObject = {
-    base: base.name,
-    data: Buffer.from(base.decode(bufOrString.toString()))
-  }
-  return decodeObject.data
+  return Buffer.from(base.decode(bufOrString.toString()))
 }
 
 /**
  * Is the given data multibase encoded?
  *
  * @param {Buffer|string} bufOrString
- * @returns {boolean}
+ * @returns {string|false} The code number or false.
  * @memberof Multibase
  */
-function isEncoded (bufOrString) {
-  if (Buffer.isBuffer(bufOrString)) {
-    bufOrString = bufOrString.toString()
-  }
+function isEncoded (bufOrString: Buffer | string): string | false {
+  bufOrString = bufOrString.toString()
 
   const code = bufOrString.substring(0, 1)
   try {
@@ -112,7 +98,7 @@ function isEncoded (bufOrString) {
  * @private
  * @returns {undefined}
  */
-function validEncode (name, buf) {
+function validEncode (name: string, buf: Buffer): void {
   const base = getBase(name)
   base.decode(buf.toString())
 }
@@ -120,10 +106,10 @@ function validEncode (name, buf) {
 function getBase (nameOrCode) {
   let base
 
-  if (constants.names[nameOrCode]) {
-    base = constants.names[nameOrCode]
-  } else if (constants.codes[nameOrCode]) {
-    base = constants.codes[nameOrCode]
+  if (constants.names[String(nameOrCode)]) {
+    base = constants.names[String(nameOrCode)]
+  } else if (constants.codes[String(nameOrCode)]) {
+    base = constants.codes[String(nameOrCode)]
   } else {
     throw errNotSupported
   }

--- a/test/constants.spec.js
+++ b/test/constants.spec.js
@@ -1,11 +1,9 @@
 /* eslint-env mocha */
-'use strict'
-
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
-const constants = require('../src/constants.js')
+const { constants } = require('../lib/constants.js')
 
 describe('constants', () => {
   it('constants indexed by name', () => {

--- a/test/multibase.spec.js
+++ b/test/multibase.spec.js
@@ -1,12 +1,10 @@
 /* eslint-env mocha */
-'use strict'
-
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
-const multibase = require('../src')
-const constants = require('../src/constants.js')
+const multibase = require('../lib')
+const { constants } = require('../lib/constants.js')
 
 const unsupportedBases = [
   ['base1']


### PR DESCRIPTION
**Status:**
I have most of the things done but need some questions answered to proceed.


**Questions:**
- [ ] [base32 `decode` returns an ArrayBuffer instead of a node js buffer](https://github.com/multiformats/js-multibase/compare/master...fahrradflucht:chore/add-flow-types?expand=1#diff-dc1baab658beb4334800170a1a67c227R4). Is that correct? Seems odd to me...
- [ ] [Do you think is it useful to have the supported base names exported as a union type for consumers?](https://github.com/multiformats/js-multibase/compare/master...fahrradflucht:chore/add-flow-types?expand=1#diff-a7748843fbda5167d065231e3a2e7a1fR12) I didn't type it like this just yet because it adds no additional type safety in here.
- [ ] Not sure what is the right way to handle [this](https://github.com/multiformats/js-multibase/pull/25/files#diff-d7e697eff3913f1acaacac8002c3b05eR26).

**Problems to solve:**
- [ ] [While I added flow typings for `base-x` I'm not sure they are recognized.](https://github.com/multiformats/js-multibase/pull/25/files#diff-a7748843fbda5167d065231e3a2e7a1fR3) At least me editor (vscode) tells me `any` for `baseX` when it gets used. Maybe someone with more flow experience can have a look? (cc @Gozala)

**Things that should happen before this can be merged:**
- [ ] Setup all necessary configurations in AEgir
- [ ] Remove configuration files from here
- [ ] Remove aegir branch reference from dependencies