### PR TITLE
feat: export list of multibase names and codes

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -37,6 +37,6 @@ const codes = constants.reduce((prev, tupple) => {
 }, {})
 
 module.exports = {
-  names: names,
-  codes: codes
+  names: Object.freeze(names),
+  codes: Object.freeze(codes)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ exports = module.exports = multibase
 exports.encode = encode
 exports.decode = decode
 exports.isEncoded = isEncoded
+exports.names = constants.names
+exports.codes = constants.codes
 
 const errNotSupported = new Error('Unsupported encoding')
 

--- a/test/constants.spec.js
+++ b/test/constants.spec.js
@@ -17,4 +17,14 @@ describe('constants', () => {
     const codes = constants.codes
     expect(Object.keys(codes).length).to.equal(16)
   })
+
+  it('names frozen', () => {
+    const names = constants.names
+    expect(Object.isFrozen(names)).to.be.true()
+  })
+
+  it('codes frozen', () => {
+    const codes = constants.codes
+    expect(Object.isFrozen(codes)).to.be.true()
+  })
 })


### PR DESCRIPTION
More convenient than `const names = require('multibase/src/constants').names`.

Access to these lists allows us to easily validate if a user provided base name/code is correct via joi or yargs.

Names and codes are frozen to prevent monkey business.