### PR TITLE
fixed bug for base64url

### DIFF
--- a/src/base64.js
+++ b/src/base64.js
@@ -20,8 +20,8 @@ module.exports = function base64 (alphabet) {
       }
 
       if (url) {
-        output = output.replace('+', '-')
-        output = output.replace('/', '_')
+        output = output.replace(/\+/g, '-')
+        output = output.replace(/\//g, '_')
       }
 
       const pad = output.indexOf('=')
@@ -33,12 +33,13 @@ module.exports = function base64 (alphabet) {
     },
     decode (input) {
       if (url) {
-        input = input.replace('+', '-')
-        input = input.replace('/', '_')
+        input = input.replace(/\+/g, '-')
+        input = input.replace(/\//g, '_')
       }
 
       for (let char of input) {
         if (alphabet.indexOf(char) < 0) {
+          console.error({char, input});
           throw new Error('invalid base64 character')
         }
       }

--- a/src/base64.js
+++ b/src/base64.js
@@ -39,7 +39,6 @@ module.exports = function base64 (alphabet) {
 
       for (let char of input) {
         if (alphabet.indexOf(char) < 0) {
-          console.error({char, input});
           throw new Error('invalid base64 character')
         }
       }


### PR DESCRIPTION
fix bug caught by below test:
```typescript
import {decode, encode, name} from 'typestub-multibase';
import {pki} from 'node-forge';

function randomString(length: number): string {
  let s = '';
  for (; s.length < length;) {
    s += Math.random()
      .toString(36)
      .split('.')[1];
  }
  return s.substring(0, length);
}

function toBuffer(b: Buffer | Uint8Array): Buffer {
  if (b instanceof Uint8Array) {
    return Buffer.from(b.buffer);
  }
  return b;
}

function test(name: name, pass: number) {
  for (let i = 0; i < pass; i++) {
    let keypair = pki.ed25519.generateKeyPair({seed: randomString(32)});
    let b = toBuffer(keypair.publicKey);
    try {
      decode(encode(name, b))
    } catch (e) {
      console.error({b});
      throw e;
    }
    let x = decode(encode(name, toBuffer(keypair.publicKey)).toString()).toString();
    let y = decode(encode(name, toBuffer(keypair.privateKey)).toString()).toString();
  }
  console.log(`passed ${pass} check on ${name}`);
}

try {
  test('base64', 1000);
} catch (e) {
  console.error('Failed test on base64', e);
}
try {
  test('base64url', 1000);
}
catch (e) {
  console.error('Failed test on base64url', e);
}
```