### PR TITLE
fix: base64url and base64urlpad encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/.npmignore
+++ b/.npmignore
@@ -18,6 +18,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/src/base64.js
+++ b/src/base64.js
@@ -20,8 +20,8 @@ module.exports = function base64 (alphabet) {
       }
 
       if (url) {
-        output = output.replace('+', '-')
-        output = output.replace('/', '_')
+        output = output.replace(/\+/g, '-')
+        output = output.replace(/\//g, '_')
       }
 
       const pad = output.indexOf('=')
@@ -33,12 +33,13 @@ module.exports = function base64 (alphabet) {
     },
     decode (input) {
       if (url) {
-        input = input.replace('+', '-')
-        input = input.replace('/', '_')
+        input = input.replace(/\+/g, '-')
+        input = input.replace(/\//g, '_')
       }
 
       for (let char of input) {
         if (alphabet.indexOf(char) < 0) {
+          console.error({char, input});
           throw new Error('invalid base64 character')
         }
       }

--- a/src/base64.js
+++ b/src/base64.js
@@ -20,8 +20,7 @@ module.exports = function base64 (alphabet) {
       }
 
       if (url) {
-        output = output.replace(/\+/g, '-')
-        output = output.replace(/\//g, '_')
+        output = output.replace(/\+/g, '-').replace(/\//g, '_')
       }
 
       const pad = output.indexOf('=')
@@ -32,11 +31,6 @@ module.exports = function base64 (alphabet) {
       return output
     },
     decode (input) {
-      if (url) {
-        input = input.replace(/\+/g, '-')
-        input = input.replace(/\//g, '_')
-      }
-
       for (let char of input) {
         if (alphabet.indexOf(char) < 0) {
           throw new Error('invalid base64 character')

--- a/src/base64.js
+++ b/src/base64.js
@@ -39,7 +39,6 @@ module.exports = function base64 (alphabet) {
 
       for (let char of input) {
         if (alphabet.indexOf(char) < 0) {
-          console.error({char, input});
           throw new Error('invalid base64 character')
         }
       }

--- a/test/multibase.spec.js
+++ b/test/multibase.spec.js
@@ -70,6 +70,7 @@ const supportedBases = [
   ['base64', 'foob', 'mZm9vYg'],
   ['base64', 'fooba', 'mZm9vYmE'],
   ['base64', 'foobar', 'mZm9vYmFy'],
+  ['base64', '÷ïÿ🥰÷ïÿ😎🥶🤯', 'mw7fDr8O/8J+lsMO3w6/Dv/CfmI7wn6W28J+krw'],
 
   ['base64pad', 'f', 'MZg=='],
   ['base64pad', 'fo', 'MZm8='],
@@ -79,13 +80,15 @@ const supportedBases = [
   ['base64pad', 'foobar', 'MZm9vYmFy'],
 
   ['base64url', '÷ïÿ', 'uw7fDr8O_'],
+  ['base64url', '÷ïÿ🥰÷ïÿ😎🥶🤯', 'uw7fDr8O_8J-lsMO3w6_Dv_CfmI7wn6W28J-krw'],
 
   ['base64urlpad', 'f', 'UZg=='],
   ['base64urlpad', 'fo', 'UZm8='],
   ['base64urlpad', 'foo', 'UZm9v'],
   ['base64urlpad', 'foob', 'UZm9vYg=='],
   ['base64urlpad', 'fooba', 'UZm9vYmE='],
-  ['base64urlpad', 'foobar', 'UZm9vYmFy']
+  ['base64urlpad', 'foobar', 'UZm9vYmFy'],
+  ['base64urlpad', '÷ïÿ🥰÷ïÿ😎🥶🤯', 'Uw7fDr8O_8J-lsMO3w6_Dv_CfmI7wn6W28J-krw==']
 ]
 
 describe('multibase', () => {


### PR DESCRIPTION
Background: `base64url` encoding is the same as `base64` encoding except instances of `+` and `/` are replaced with `-` and `_`.

This PR fixes and adds tests for `base64url` and `base64urlpad` to ensure **multiple** instances of `+` and `/` are replaced with `-` and `_` appropriately.

closes #35