### PR TITLE
docs: fix docs for decode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,13 +51,8 @@ function encode (nameOrCode, buf) {
 }
 
 /**
- *
- * Takes a buffer or string encoded with multibase header
- * decodes it and returns an object with the decoded buffer
- * and the encoded type { base: <name>, data: <buffer> }
- *
- * from @theobat : This is not what the multibase.spec.js test is waiting for,
- * hence the return decodeObject.data
+ * Takes a buffer or string encoded with multibase header, decodes it and
+ * returns the decoded buffer
  *
  * @param {Buffer|string} bufOrString
  * @returns {Buffer}
@@ -77,12 +72,7 @@ function decode (bufOrString) {
   }
 
   const base = getBase(code)
-
-  const decodeObject = {
-    base: base.name,
-    data: Buffer.from(base.decode(bufOrString.toString()))
-  }
-  return decodeObject.data
+  return Buffer.from(base.decode(bufOrString.toString()))
 }
 
 /**


### PR DESCRIPTION
tidy up legacy cruft in the decode method.

Closes #30 