### PR TITLE
Export Multibase.Buffer for browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ exports.decode = decode
 exports.isEncoded = isEncoded
 exports.names = Object.freeze(Object.keys(constants.names))
 exports.codes = Object.freeze(Object.keys(constants.codes))
+exports.Buffer = Buffer;
 
 const errNotSupported = new Error('Unsupported encoding')
 


### PR DESCRIPTION
I can't get `Multibase.Buffer` working in the browser without this patch.
Not sure if this is the way to go.