### PR TITLE
fix: throw new error object so stack traces are valid

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,6 @@ exports.isEncoded = isEncoded
 exports.names = Object.freeze(Object.keys(constants.names))
 exports.codes = Object.freeze(Object.keys(constants.codes))
 
-const errNotSupported = new Error('Unsupported encoding')
-
 /**
  * Create a new buffer with the multibase varint+code.
  *
@@ -120,7 +118,7 @@ function getBase (nameOrCode) {
   } else if (constants.codes[nameOrCode]) {
     base = constants.codes[nameOrCode]
   } else {
-    throw errNotSupported
+    throw new Error('Unsupported encoding')
   }
 
   if (!base.isImplemented()) {


### PR DESCRIPTION
If the a thrown error was not created at the throw site, the stack trace of that error will not reflect where the error was thrown from making it harder to debug problems.

This PR removes the cached error object and instead creates a new one when required.