### PR TITLE
feat: accept Uint8Arrays in place of Buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "base-x": "^3.0.8",
-    "buffer": "^5.5.0"
+    "buffer": "^5.5.0",
+    "web-encoding": "^1.0.1"
   },
   "devDependencies": {
     "aegir": "^25.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "base-x": "^3.0.8",
     "buffer": "^5.5.0",
-    "web-encoding": "^1.0.1"
+    "web-encoding": "^1.0.2"
   },
   "devDependencies": {
     "aegir": "^25.0.0",

--- a/src/base.js
+++ b/src/base.js
@@ -1,7 +1,22 @@
+// @ts-check
 'use strict'
 const { Buffer } = require('buffer')
 
+/**
+ * @typedef {Object} Codec
+ * @property {function(Uint8Array):string} encode
+ * @property {function(string):Uint8Array} decode
+ *
+ * @typedef {function(string):Codec} CodecFactory
+ */
+
 class Base {
+  /**
+   * @param {string} name
+   * @param {string} code
+   * @param {CodecFactory} implementation
+   * @param {string} alphabet
+   */
   constructor (name, code, implementation, alphabet) {
     this.name = name
     this.code = code
@@ -10,10 +25,18 @@ class Base {
     this.engine = implementation(alphabet)
   }
 
+  /**
+   * @param {Uint8Array} buf
+   * @returns {string}
+   */
   encode (buf) {
     return this.engine.encode(buf)
   }
 
+  /**
+   * @param {string} string
+   * @returns {Uint8Array}
+   */
   decode (string) {
     for (const char of string) {
       if (this.alphabet && this.alphabet.indexOf(char) < 0) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,18 +1,24 @@
+// @ts-check
 'use strict'
 
 const baseX = require('base-x')
-const { Buffer } = require('buffer')
 const Base = require('./base.js')
 const rfc4648 = require('./rfc4648')
+const { decodeText, encodeText } = require('./util')
 
 const identity = () => {
   return {
-    encode: (data) => Buffer.from(data).toString(),
-    decode: (string) => Buffer.from(string)
+    encode: decodeText,
+    decode: encodeText
   }
 }
 
-// name, code, implementation, alphabet
+/**
+ * @typedef {import('./base').CodecFactory} CodecFactory
+ *
+ * name, code, implementation, alphabet
+ * @type {Array<[string, string, CodecFactory, string]>}
+ */
 const constants = [
   ['identity', '\x00', identity, ''],
   ['base2', '0', rfc4648(1), '01'],

--- a/src/rfc4648.js
+++ b/src/rfc4648.js
@@ -1,5 +1,14 @@
+// @ts-check
 'use strict'
 
+/** @typedef {import('./base').CodecFactory} CodecFactory */
+
+/**
+ * @param {string} string
+ * @param {string} alphabet
+ * @param {number} bitsPerChar
+ * @returns {Uint8Array}
+ */
 const decode = (string, alphabet, bitsPerChar) => {
   // Build the character lookup table:
   const codes = {}
@@ -46,6 +55,12 @@ const decode = (string, alphabet, bitsPerChar) => {
   return out
 }
 
+/**
+ * @param {Uint8Array} data
+ * @param {string} alphabet
+ * @param {number} bitsPerChar
+ * @returns {string}
+ */
 const encode = (data, alphabet, bitsPerChar) => {
   const pad = alphabet[alphabet.length - 1] === '='
   const mask = (1 << bitsPerChar) - 1
@@ -80,11 +95,23 @@ const encode = (data, alphabet, bitsPerChar) => {
   return out
 }
 
+/**
+ * @param {number} bitsPerChar
+ * @returns {CodecFactory}
+ */
 module.exports = (bitsPerChar) => (alphabet) => {
   return {
+    /**
+     * @param {Uint8Array} input
+     * @returns {string}
+     */
     encode (input) {
       return encode(input, alphabet, bitsPerChar)
     },
+    /**
+     * @param {string} input
+     * @returns {Uint8Array}
+     */
     decode (input) {
       return decode(input, alphabet, bitsPerChar)
     }

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,33 @@
+// @ts-check
+'use strict'
+
+const { Buffer } = require('buffer')
+
+const textDecoder = typeof TextDecoder !== 'undefined'
+  ? new TextDecoder()
+  : new (require('util').TextDecoder)()
+
+const textEncoder = typeof TextEncoder !== 'undefined'
+  ? new TextEncoder()
+  : new (require('util').TextEncoder)()
+
+/**
+ * @param {ArrayBufferView|ArrayBuffer} bytes
+ * @returns {string}
+ */
+const decodeText = (bytes) => textDecoder.decode(bytes)
+
+/**
+ * @param {string} text
+ * @returns {Uint8Array}
+ */
+const encodeText = (text) => textEncoder.encode(text)
+
+/**
+ * @param {ArrayBufferView} bytes
+ * @returns {Buffer}
+ */
+const asBuffer = ({ buffer, byteLength, byteOffset }) =>
+  Buffer.from(buffer, byteOffset, byteLength)
+
+module.exports = { decodeText, encodeText, asBuffer }

--- a/src/util.js
+++ b/src/util.js
@@ -2,21 +2,16 @@
 'use strict'
 
 const { Buffer } = require('buffer')
+const { TextEncoder, TextDecoder } = require('web-encoding')
 
-const textDecoder = typeof TextDecoder !== 'undefined'
-  ? new TextDecoder()
-  : new (require('util').TextDecoder)()
-
-const textEncoder = typeof TextEncoder !== 'undefined'
-  ? new TextEncoder()
-  : new (require('util').TextEncoder)()
-
+const textDecoder = new TextDecoder()
 /**
  * @param {ArrayBufferView|ArrayBuffer} bytes
  * @returns {string}
  */
 const decodeText = (bytes) => textDecoder.decode(bytes)
 
+const textEncoder = new TextEncoder()
 /**
  * @param {string} text
  * @returns {Uint8Array}

--- a/test/multibase.spec.js
+++ b/test/multibase.spec.js
@@ -84,6 +84,11 @@ const supportedBases = [
   ['base64urlpad', '÷ïÿ🥰÷ïÿ😎🥶🤯', 'Uw7fDr8O_8J-lsMO3w6_Dv_CfmI7wn6W28J-krw==']
 ]
 
+const they = (label, def) => {
+  it(`${label} (Buffer)`, def.bind(null, Buffer.from))
+  it(`${label} (Uint8Array)`, def.bind(null, encodeText))
+}
+
 describe('multibase', () => {
   describe('generic', () => {
     it('fails on no args', () => {
@@ -96,15 +101,15 @@ describe('multibase', () => {
       }).to.throw(Error)
     })
 
-    it('fails on non supported name', () => {
+    they('fails on non supported name', (encode) => {
       expect(() => {
-        multibase('base1001', encodeText('meh'))
+        multibase('base1001', encode('meh'))
       }).to.throw(Error)
     })
 
-    it('fails on non supported code', () => {
+    they('fails on non supported code', (encode) => {
       expect(() => {
-        multibase('6', encodeText('meh'))
+        multibase('6', encode('meh'))
       }).to.throw(Error)
     })
   })
@@ -115,28 +120,28 @@ describe('multibase', () => {
     const output = elements[2]
     const base = constants.names[name]
     describe(name, () => {
-      it('adds multibase code to valid encoded buffer, by name', () => {
+      they('adds multibase code to valid encoded buffer, by name', (encode) => {
         if (typeof input === 'string') {
-          const buf = encodeText(input)
-          const encodedBuf = encodeText(base.encode(buf))
+          const buf = encode(input)
+          const encodedBuf = encode(base.encode(buf))
           const multibasedBuf = multibase(base.name, encodedBuf)
           expect(multibasedBuf.toString()).to.equal(output)
         } else {
-          const encodedBuf = encodeText(base.encode(input))
+          const encodedBuf = encode(base.encode(input))
           const multibasedBuf = multibase(base.name, encodedBuf)
           expect(multibasedBuf.toString()).to.equal(output)
         }
       })
 
-      it('adds multibase code to valid encoded buffer, by code', () => {
-        const buf = encodeText(input)
-        const encodedBuf = encodeText(base.encode(buf))
+      they('adds multibase code to valid encoded buffer, by code', (encode) => {
+        const buf = encode(input)
+        const encodedBuf = encode(base.encode(buf))
         const multibasedBuf = multibase(base.code, encodedBuf)
         expect(multibasedBuf.toString()).to.equal(output)
       })
 
-      it('fails to add multibase code to invalid encoded buffer', () => {
-        const nonEncodedBuf = encodeText('^!@$%!#$%@#y')
+      they('fails to add multibase code to invalid encoded buffer', (encode) => {
+        const nonEncodedBuf = encode('^!@$%!#$%@#y')
         expect(() => {
           multibase(base.name, nonEncodedBuf)
         }).to.throw(Error)
@@ -147,8 +152,8 @@ describe('multibase', () => {
         expect(name).to.equal(base.name)
       })
 
-      it('isEncoded buffer', () => {
-        const multibasedStr = encodeText(output)
+      they('isEncoded buffer', (encode) => {
+        const multibasedStr = encode(output)
         const name = multibase.isEncoded(multibasedStr)
         expect(name).to.equal(base.name)
       })
@@ -162,8 +167,8 @@ describe('multibase.encode ', () => {
     const input = elements[1]
     const output = elements[2]
     describe(name, () => {
-      it('encodes a buffer', () => {
-        const buf = encodeText(input)
+      they('encodes a buffer', (encode) => {
+        const buf = encode(input)
         const multibasedBuf = multibase.encode(name, buf)
         expect(multibasedBuf.toString()).to.equal(output)
       })
@@ -191,8 +196,8 @@ describe('multibase.decode', () => {
         expect(buf).to.eql(Buffer.from(input))
       })
 
-      it('decodes a buffer', () => {
-        const multibasedBuf = encodeText(output)
+      they('decodes a buffer', (encode) => {
+        const multibasedBuf = encode(output)
         const buf = multibase.decode(multibasedBuf)
         expect(buf).to.eql(Buffer.from(input))
       })
@@ -203,9 +208,9 @@ describe('multibase.decode', () => {
 for (const elements of unsupportedBases) {
   const name = elements[0]
   describe(name, () => {
-    it('fails on non implemented name', () => {
+    they('fails on non implemented name', (encode) => {
       expect(() => {
-        multibase(name, encodeText('meh'))
+        multibase(name, encode('meh'))
       }).to.throw(Error)
     })
   })

--- a/test/multibase.spec.js
+++ b/test/multibase.spec.js
@@ -3,6 +3,7 @@
 
 const { expect } = require('aegir/utils/chai')
 const { Buffer } = require('buffer')
+const { encodeText } = require('../src/util')
 const multibase = require('../src')
 const constants = require('../src/constants.js')
 
@@ -10,8 +11,8 @@ const unsupportedBases = []
 
 const supportedBases = [
 
-  ['base16', Buffer.from([0x01]), 'f01'],
-  ['base16', Buffer.from([15]), 'f0f'],
+  ['base16', Buffer.from([0x01]).toString(), 'f01'],
+  ['base16', Buffer.from([15]).toString(), 'f0f'],
   ['base16', 'f', 'f66'],
   ['base16', 'fo', 'f666f'],
   ['base16', 'foo', 'f666f6f'],
@@ -97,13 +98,13 @@ describe('multibase', () => {
 
     it('fails on non supported name', () => {
       expect(() => {
-        multibase('base1001', Buffer.from('meh'))
+        multibase('base1001', encodeText('meh'))
       }).to.throw(Error)
     })
 
     it('fails on non supported code', () => {
       expect(() => {
-        multibase('6', Buffer.from('meh'))
+        multibase('6', encodeText('meh'))
       }).to.throw(Error)
     })
   })
@@ -116,26 +117,26 @@ describe('multibase', () => {
     describe(name, () => {
       it('adds multibase code to valid encoded buffer, by name', () => {
         if (typeof input === 'string') {
-          const buf = Buffer.from(input)
-          const encodedBuf = Buffer.from(base.encode(buf))
+          const buf = encodeText(input)
+          const encodedBuf = encodeText(base.encode(buf))
           const multibasedBuf = multibase(base.name, encodedBuf)
           expect(multibasedBuf.toString()).to.equal(output)
         } else {
-          const encodedBuf = Buffer.from(base.encode(input))
+          const encodedBuf = encodeText(base.encode(input))
           const multibasedBuf = multibase(base.name, encodedBuf)
           expect(multibasedBuf.toString()).to.equal(output)
         }
       })
 
       it('adds multibase code to valid encoded buffer, by code', () => {
-        const buf = Buffer.from(input)
-        const encodedBuf = Buffer.from(base.encode(buf))
+        const buf = encodeText(input)
+        const encodedBuf = encodeText(base.encode(buf))
         const multibasedBuf = multibase(base.code, encodedBuf)
         expect(multibasedBuf.toString()).to.equal(output)
       })
 
       it('fails to add multibase code to invalid encoded buffer', () => {
-        const nonEncodedBuf = Buffer.from('^!@$%!#$%@#y')
+        const nonEncodedBuf = encodeText('^!@$%!#$%@#y')
         expect(() => {
           multibase(base.name, nonEncodedBuf)
         }).to.throw(Error)
@@ -147,7 +148,7 @@ describe('multibase', () => {
       })
 
       it('isEncoded buffer', () => {
-        const multibasedStr = Buffer.from(output)
+        const multibasedStr = encodeText(output)
         const name = multibase.isEncoded(multibasedStr)
         expect(name).to.equal(base.name)
       })
@@ -162,7 +163,7 @@ describe('multibase.encode ', () => {
     const output = elements[2]
     describe(name, () => {
       it('encodes a buffer', () => {
-        const buf = Buffer.from(input)
+        const buf = encodeText(input)
         const multibasedBuf = multibase.encode(name, buf)
         expect(multibasedBuf.toString()).to.equal(output)
       })
@@ -191,7 +192,7 @@ describe('multibase.decode', () => {
       })
 
       it('decodes a buffer', () => {
-        const multibasedBuf = Buffer.from(output)
+        const multibasedBuf = encodeText(output)
         const buf = multibase.decode(multibasedBuf)
         expect(buf).to.eql(Buffer.from(input))
       })
@@ -204,7 +205,7 @@ for (const elements of unsupportedBases) {
   describe(name, () => {
     it('fails on non implemented name', () => {
       expect(() => {
-        multibase(name, Buffer.from('meh'))
+        multibase(name, encodeText('meh'))
       }).to.throw(Error)
     })
   })


### PR DESCRIPTION
This pull request relaxes input type from `Buffer` to `Uint8Array`. It still returns `Buffer`s back to ensure backwards compatibility. It also adds missing TS JSDoc comments as they helped me understand interfaces between components. 