### PR TITLE
fix: return Uint8Arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "base-x": "^3.0.8",
-    "buffer": "^5.5.0",
     "web-encoding": "^1.0.2"
   },
   "devDependencies": {

--- a/src/base.js
+++ b/src/base.js
@@ -1,6 +1,7 @@
 // @ts-check
 'use strict'
-const { Buffer } = require('buffer')
+
+const { encodeText } = require('./util')
 
 /**
  * @typedef {Object} Codec
@@ -20,7 +21,7 @@ class Base {
   constructor (name, code, implementation, alphabet) {
     this.name = name
     this.code = code
-    this.codeBuf = Buffer.from(this.code)
+    this.codeBuf = encodeText(this.code)
     this.alphabet = alphabet
     this.engine = implementation(alphabet)
   }

--- a/src/util.js
+++ b/src/util.js
@@ -21,14 +21,10 @@ const encodeText = (text) => textEncoder.encode(text)
  * Returns a new Uint8Array created by concatenating the passed Arrays
  *
  * @param {Array<ArrayLike<Number>>} arrs
- * @param {Number} [length]
+ * @param {Number} length
  * @returns {Uint8Array}
  */
 function concat (arrs, length) {
-  if (!length) {
-    length = arrs.reduce((acc, curr) => acc + curr.length, 0)
-  }
-
   const output = new Uint8Array(length)
   let offset = 0
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,6 @@
 // @ts-check
 'use strict'
 
-const { Buffer } = require('buffer')
 const { TextEncoder, TextDecoder } = require('web-encoding')
 
 const textDecoder = new TextDecoder()
@@ -19,10 +18,26 @@ const textEncoder = new TextEncoder()
 const encodeText = (text) => textEncoder.encode(text)
 
 /**
- * @param {ArrayBufferView} bytes
- * @returns {Buffer}
+ * Returns a new Uint8Array created by concatenating the passed Arrays
+ *
+ * @param {Array<ArrayLike<Number>>} arrs
+ * @param {Number} [length]
+ * @returns {Uint8Array}
  */
-const asBuffer = ({ buffer, byteLength, byteOffset }) =>
-  Buffer.from(buffer, byteOffset, byteLength)
+function concat (arrs, length) {
+  if (!length) {
+    length = arrs.reduce((acc, curr) => acc + curr.length, 0)
+  }
 
-module.exports = { decodeText, encodeText, asBuffer }
+  const output = new Uint8Array(length)
+  let offset = 0
+
+  for (const arr of arrs) {
+    output.set(arr, offset)
+    offset += arr.length
+  }
+
+  return output
+}
+
+module.exports = { decodeText, encodeText, concat }

--- a/test/multibase.spec.js
+++ b/test/multibase.spec.js
@@ -2,8 +2,7 @@
 'use strict'
 
 const { expect } = require('aegir/utils/chai')
-const { Buffer } = require('buffer')
-const { encodeText } = require('../src/util')
+const { encodeText, decodeText } = require('../src/util')
 const multibase = require('../src')
 const constants = require('../src/constants.js')
 
@@ -11,8 +10,8 @@ const unsupportedBases = []
 
 const supportedBases = [
 
-  ['base16', Buffer.from([0x01]).toString(), 'f01'],
-  ['base16', Buffer.from([15]).toString(), 'f0f'],
+  ['base16', decodeText(Uint8Array.from([0x01])), 'f01'],
+  ['base16', decodeText(Uint8Array.from([15])), 'f0f'],
   ['base16', 'f', 'f66'],
   ['base16', 'fo', 'f666f'],
   ['base16', 'foo', 'f666f6f'],
@@ -85,7 +84,6 @@ const supportedBases = [
 ]
 
 const they = (label, def) => {
-  it(`${label} (Buffer)`, def.bind(null, Buffer.from))
   it(`${label} (Uint8Array)`, def.bind(null, encodeText))
 }
 
@@ -120,27 +118,27 @@ describe('multibase', () => {
     const output = elements[2]
     const base = constants.names[name]
     describe(name, () => {
-      they('adds multibase code to valid encoded buffer, by name', (encode) => {
+      they('adds multibase code to valid encoded Uint8Array, by name', (encode) => {
         if (typeof input === 'string') {
           const buf = encode(input)
           const encodedBuf = encode(base.encode(buf))
           const multibasedBuf = multibase(base.name, encodedBuf)
-          expect(multibasedBuf.toString()).to.equal(output)
+          expect(decodeText(multibasedBuf)).to.equal(output)
         } else {
           const encodedBuf = encode(base.encode(input))
           const multibasedBuf = multibase(base.name, encodedBuf)
-          expect(multibasedBuf.toString()).to.equal(output)
+          expect(decodeText(multibasedBuf)).to.equal(output)
         }
       })
 
-      they('adds multibase code to valid encoded buffer, by code', (encode) => {
+      they('adds multibase code to valid encoded Uint8Array, by code', (encode) => {
         const buf = encode(input)
         const encodedBuf = encode(base.encode(buf))
         const multibasedBuf = multibase(base.code, encodedBuf)
-        expect(multibasedBuf.toString()).to.equal(output)
+        expect(decodeText(multibasedBuf)).to.equal(output)
       })
 
-      they('fails to add multibase code to invalid encoded buffer', (encode) => {
+      they('fails to add multibase code to invalid encoded Uint8Array', (encode) => {
         const nonEncodedBuf = encode('^!@$%!#$%@#y')
         expect(() => {
           multibase(base.name, nonEncodedBuf)
@@ -152,7 +150,7 @@ describe('multibase', () => {
         expect(name).to.equal(base.name)
       })
 
-      they('isEncoded buffer', (encode) => {
+      they('isEncoded Uint8Array', (encode) => {
         const multibasedStr = encode(output)
         const name = multibase.isEncoded(multibasedStr)
         expect(name).to.equal(base.name)
@@ -167,10 +165,10 @@ describe('multibase.encode ', () => {
     const input = elements[1]
     const output = elements[2]
     describe(name, () => {
-      they('encodes a buffer', (encode) => {
+      they('encodes a Uint8Array', (encode) => {
         const buf = encode(input)
         const multibasedBuf = multibase.encode(name, buf)
-        expect(multibasedBuf.toString()).to.equal(output)
+        expect(decodeText(multibasedBuf)).to.equal(output)
       })
     })
   }
@@ -180,7 +178,7 @@ describe('multibase.encode ', () => {
     const decoded = multibase.decode(encodedStr)
 
     const encoded = multibase.encode('c', decoded)
-    expect(encodedStr).to.be.eq(encoded.toString())
+    expect(encodedStr).to.be.eq(decodeText(encoded))
   })
 })
 
@@ -193,13 +191,13 @@ describe('multibase.decode', () => {
       it('decodes a string', () => {
         const multibasedStr = output
         const buf = multibase.decode(multibasedStr)
-        expect(buf).to.eql(Buffer.from(input))
+        expect(buf).to.eql(encodeText(input))
       })
 
-      they('decodes a buffer', (encode) => {
+      they('decodes a Uint8Array', (encode) => {
         const multibasedBuf = encode(output)
         const buf = multibase.decode(multibasedBuf)
-        expect(buf).to.eql(Buffer.from(input))
+        expect(buf).to.eql(encodeText(input))
       })
     })
   }
@@ -241,7 +239,7 @@ describe('multibase.codes', () => {
 })
 
 describe('multibase.isEncoded', () => {
-  it('should not throw for non string/buffer input', () => {
+  it('should not throw for non String/Uint8Array input', () => {
     const invalidInputs = [
       null,
       undefined,

--- a/test/spec-test1.spec.js
+++ b/test/spec-test1.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
+const { decodeText, encodeText } = require('../src/util')
 const { expect } = require('aegir/utils/chai')
 const multibase = require('../src')
 const constants = require('../src/constants.js')
@@ -37,33 +37,33 @@ describe('spec test1', () => {
     const base = constants.names[name]
 
     describe(name, () => {
-      it('should encode buffer by base name', () => {
-        const out = multibase.encode(name, Buffer.from(input))
-        expect(out.toString()).to.equal(output)
+      it('should encode Uint8Array by base name', () => {
+        const out = multibase.encode(name, encodeText(input))
+        expect(decodeText(out)).to.equal(output)
       })
 
-      it('should encode buffer by base code', () => {
-        const out = multibase.encode(base.code, Buffer.from(input))
-        expect(out.toString()).to.equal(output)
+      it('should encode Uint8Array by base code', () => {
+        const out = multibase.encode(base.code, encodeText(input))
+        expect(decodeText(out)).to.equal(output)
       })
 
       it('should decode string', () => {
         const out = multibase.decode(output)
-        expect(out.toString()).to.equal(input)
+        expect(decodeText(out)).to.equal(input)
       })
 
-      it('should prefix encoded buffer', () => {
+      it('should prefix encoded Uint8Array', () => {
         const base = constants.names[name]
-        const data = base.encode(Buffer.from(input))
+        const data = base.encode(encodeText(input))
 
-        expect(multibase(name, Buffer.from(data)).toString()).to.equal(output)
+        expect(decodeText(multibase(name, encodeText(data)))).to.equal(output)
       })
 
       it('should fail decode with invalid char', function () {
         if (name === 'identity') {
           return this.skip()
         }
-        const nonEncodedBuf = Buffer.from(base.code + '^!@$%!#$%@#y')
+        const nonEncodedBuf = encodeText(base.code + '^!@$%!#$%@#y')
         expect(() => {
           multibase.decode(nonEncodedBuf)
         }).to.throw(Error, 'invalid character \'^\' in \'^!@$%!#$%@#y\'')

--- a/test/spec-test2.spec.js
+++ b/test/spec-test2.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
+const { decodeText, encodeText } = require('../src/util')
 const { expect } = require('aegir/utils/chai')
 const multibase = require('../src')
 const constants = require('../src/constants.js')
@@ -38,18 +38,18 @@ describe('spec test2', () => {
 
     describe(name, () => {
       it('should encode buffer by base name', () => {
-        const out = multibase.encode(name, Buffer.from(input))
-        expect(out.toString()).to.equal(output)
+        const out = multibase.encode(name, encodeText(input))
+        expect(decodeText(out)).to.equal(output)
       })
 
       it('should encode buffer by base code', () => {
-        const out = multibase.encode(base.code, Buffer.from(input))
-        expect(out.toString()).to.equal(output)
+        const out = multibase.encode(base.code, encodeText(input))
+        expect(decodeText(out)).to.equal(output)
       })
 
       it('should decode string', () => {
         const out = multibase.decode(output)
-        expect(out.toString()).to.equal(input)
+        expect(decodeText(out)).to.equal(input)
       })
     })
   }

--- a/test/spec-test3.spec.js
+++ b/test/spec-test3.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
+const { decodeText, encodeText } = require('../src/util')
 const { expect } = require('aegir/utils/chai')
 const multibase = require('../src')
 const constants = require('../src/constants.js')
@@ -38,18 +38,18 @@ describe('spec test3', () => {
 
     describe(name, () => {
       it('should encode buffer by base name', () => {
-        const out = multibase.encode(name, Buffer.from(input))
-        expect(out.toString()).to.equal(output)
+        const out = multibase.encode(name, encodeText(input))
+        expect(decodeText(out)).to.equal(output)
       })
 
       it('should encode buffer by base code', () => {
-        const out = multibase.encode(base.code, Buffer.from(input))
-        expect(out.toString()).to.equal(output)
+        const out = multibase.encode(base.code, encodeText(input))
+        expect(decodeText(out)).to.equal(output)
       })
 
       it('should decode string', () => {
         const out = multibase.decode(output)
-        expect(out.toString()).to.equal(input)
+        expect(decodeText(out)).to.equal(input)
       })
     })
   }

--- a/test/spec-test4.spec.js
+++ b/test/spec-test4.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
+const { decodeText, encodeText } = require('../src/util')
 const { expect } = require('aegir/utils/chai')
 const multibase = require('../src')
 const constants = require('../src/constants.js')
@@ -37,19 +37,19 @@ describe('spec test4', () => {
     const base = constants.names[name]
 
     describe(name, () => {
-      it('should encode buffer by base name', () => {
-        const out = multibase.encode(name, Buffer.from(input))
-        expect(out.toString()).to.equal(output)
+      it('should encode Uint8Array by base name', () => {
+        const out = multibase.encode(name, encodeText(input))
+        expect(decodeText(out)).to.equal(output)
       })
 
-      it('should encode buffer by base code', () => {
-        const out = multibase.encode(base.code, Buffer.from(input))
-        expect(out.toString()).to.equal(output)
+      it('should encode Uint8Array by base code', () => {
+        const out = multibase.encode(base.code, encodeText(input))
+        expect(decodeText(out)).to.equal(output)
       })
 
       it('should decode string', () => {
         const out = multibase.decode(output)
-        expect(out.toString()).to.equal(input)
+        expect(decodeText(out)).to.equal(input)
       })
     })
   }

--- a/test/spec-test5.spec.js
+++ b/test/spec-test5.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
+const { decodeText, encodeText } = require('../src/util')
 const { expect } = require('aegir/utils/chai')
 const multibase = require('../src')
 const constants = require('../src/constants.js')
@@ -38,18 +38,18 @@ describe('spec test5', () => {
 
     describe(name, () => {
       it('should encode buffer by base name', () => {
-        const out = multibase.encode(name, Buffer.from(input))
-        expect(out.toString()).to.equal(output)
+        const out = multibase.encode(name, encodeText(input))
+        expect(decodeText(out)).to.equal(output)
       })
 
       it('should encode buffer by base code', () => {
-        const out = multibase.encode(base.code, Buffer.from(input))
-        expect(out.toString()).to.equal(output)
+        const out = multibase.encode(base.code, encodeText(input))
+        expect(decodeText(out)).to.equal(output)
       })
 
       it('should decode string', () => {
         const out = multibase.decode(output)
-        expect(out.toString()).to.equal(input)
+        expect(decodeText(out)).to.equal(input)
       })
     })
   }

--- a/test/spec-test6.spec.js
+++ b/test/spec-test6.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const { decodeText } = require('../src/util')
 const { expect } = require('aegir/utils/chai')
 const multibase = require('../src')
 const input = 'hello world'
@@ -24,7 +25,7 @@ describe('spec test6', () => {
     describe(name, () => {
       it('should decode string', () => {
         const out = multibase.decode(output)
-        expect(out.toString()).to.equal(input)
+        expect(decodeText(out)).to.equal(input)
       })
     })
   }


### PR DESCRIPTION
Return `Uint8Array`s instead of node `Buffer`s.

BREAKING CHANGE:

- node `Buffer`s are not returned any more, only `Uint8Array`s