### PR TITLE
chore: use version of base-x without buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "coverage-publish": "aegir coverage publish"
   },
   "dependencies": {
-    "base-x": "^3.0.8",
+    "base-x": "achingbrain/base-x#feature/return-uint8arrays",
     "web-encoding": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "coverage-publish": "aegir coverage publish"
   },
   "dependencies": {
-    "base-x": "achingbrain/base-x#feature/return-uint8arrays",
+    "@multiformats/base-x": "^4.0.1",
     "web-encoding": "^1.0.2"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
+    "aegir": "^26.0.0",
     "benchmark": "^2.1.4"
   },
   "engines": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
 // @ts-check
 'use strict'
 
-const baseX = require('base-x')
+const baseX = require('@multiformats/base-x')
 const Base = require('./base.js')
 const rfc4648 = require('./rfc4648')
 const { decodeText, encodeText } = require('./util')


### PR DESCRIPTION
Drops `dist/index.min.js` size after running `npm run build` from 29kb to 6.5kb.

Depends on:

- [ ] ~https://github.com/cryptocoinjs/base-x/pull/68~ (we are using a [published fork](https://www.npmjs.com/package/@multiformats/base-x) until this is merged)