### PR TITLE
Fix incompatibility with zii

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,10 +114,10 @@ function validEncode (name, buf) {
  * @throws {Error} Will throw if the encoding is not supported
  */
 function encoding (nameOrCode) {
-  if (constants.names[/** @type {BaseName} */(nameOrCode)]) {
-    return constants.names[/** @type {BaseName} */(nameOrCode)]
-  } else if (constants.codes[/** @type {BaseCode} */(nameOrCode)]) {
+  if (constants.codes[/** @type {BaseCode} */(nameOrCode)]) {
     return constants.codes[/** @type {BaseCode} */(nameOrCode)]
+  } else if (constants.names[/** @type {BaseName} */(nameOrCode)]) {
+    return constants.names[/** @type {BaseName} */(nameOrCode)]
   } else {
     throw new Error(`Unsupported encoding: ${nameOrCode}`)
   }


### PR DESCRIPTION
Fixes #80.  Just has to check for the encoding by code first instead of by name first.  Reason being that zii adds a default `.z` and since the name list doesn't have a "z" element, it triggers zii.  But codes does have a "z" element already, so it doesn't trigger zii's default.