### PR TITLE
chore: remove web-encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "release-major": "aegir release --type major"
   },
   "dependencies": {
-    "@multiformats/base-x": "^4.0.1",
-    "web-encoding": "^1.1.0"
+    "@multiformats/base-x": "^4.0.1"
   },
   "devDependencies": {
     "aegir": "^31.0.0",

--- a/src/util.js
+++ b/src/util.js
@@ -1,8 +1,5 @@
 'use strict'
 
-// @ts-ignore
-const { TextEncoder, TextDecoder } = require('web-encoding')
-
 const textDecoder = new TextDecoder()
 /**
  * @param {ArrayBufferView|ArrayBuffer} bytes


### PR DESCRIPTION
TextEncoder and TextDecoder are supported everywhere we run so the extra dep is not necessary.