### PR TITLE
fix: return basename or false from isEncoded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,6 @@ function decode (data) {
  * Is the given data multibase encoded?
  *
  * @param {Uint8Array|string} data
- * @returns {false | string}
  */
 function isEncoded (data) {
   if (data instanceof Uint8Array) {


### PR DESCRIPTION
The return type should be BaseName or false, remove the `@returns`
annotation and let the compiler figure it out.